### PR TITLE
Python 2/3 compatibility, fixes #6

### DIFF
--- a/ipinfo/cache/interface.py
+++ b/ipinfo/cache/interface.py
@@ -3,9 +3,11 @@ Abstract interface for caching IPinfo data.
 """
 
 import abc
+import six
 
 
-class CacheInterface(metaclass=abc.ABCMeta):
+@six.add_metaclass(abc.ABCMeta)
+class CacheInterface():
     """Interface for using custom cache."""
 
     @abc.abstractmethod


### PR DESCRIPTION
I went with this solution for making `abcMeta` version compatible since `six` was already in requirements:
https://stackoverflow.com/a/35673504/4396927

Tested with Python 2.7.10 and Python 3.7.0