### PR TITLE
Bug fix to bad coordinate reading on private IPs.

### DIFF
--- a/ipinfo/details.py
+++ b/ipinfo/details.py
@@ -14,7 +14,7 @@ class Details:
         if attr in self.details:
             return self.details[attr]
         else:
-            raise AttributeError('{attr} is not a valid attribute of Details'.format(attr))
+            raise AttributeError('{} is not a valid attribute of Details'.format(attr))
 
     @property
     def all(self):

--- a/ipinfo/handler.py
+++ b/ipinfo/handler.py
@@ -46,13 +46,7 @@ class Handler:
         raw_details = self._requestDetails(ip_address)
         raw_details['country_name'] = self.countries.get(raw_details.get('country'))
         raw_details['ip_address'] = ipaddress.ip_address(raw_details.get('ip'))
-
-        lat, lon = None, None
-        coords = tuple(raw_details.get('loc', '').split(','))
-        if coords:
-            lat, lon = coords[0], coords[1]
-        raw_details['latitude'], raw_details['longitude'] = lat, lon
-
+        raw_details['latitude'], raw_details['longitude'] = self._read_coords(raw_details.get('loc'))
         return Details(raw_details)
 
     def _requestDetails(self, ip_address=None):
@@ -75,12 +69,19 @@ class Handler:
         headers = {
             'user-agent': 'IPinfoClient/Python{version}/1.0'.format(version=sys.version_info[0]),
             'accept': 'application/json'
-            }
+        }
 
         if self.access_token:
             headers['authorization'] = 'Bearer {}'.format(self.access_token)
 
         return headers
+
+    def _read_coords(self, location):
+        lat, lon = None, None
+        coords = tuple(location.split(',')) if location else ''
+        if len(coords) == 2 and coords[0] and coords[1]:
+            lat, lon = coords[0], coords[1]
+        return lat, lon
 
     def _read_country_names(self, countries_file=None):
         """Read list of countries from specified country file or default file."""

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ You can visit our developer docs at https://ipinfo.io/developers.
 """
 
 setup(name='ipinfo',
-      version='1.1.0',
+      version='1.1.1',
       description='Official Python library for IPInfo',
       long_description=long_description,
       url='https://github.com/ipinfo/python',


### PR DESCRIPTION
Closes #10 

Fixes an issue where geolocation data isn't available (e.g. for private IPs) and we try to retrieve it by giving an index, without checking if it's valid for the list.

Was able to reproduce the issue in #10 with:

```python
>>> details = handler.getDetails('10.62.100.139')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/mslm/dev/ipinfo/python/ipinfo/handler.py", line 53, in getDetails
    lat, lon = coords[0], coords[1]
IndexError: tuple index out of range
```

After the fix:

```python
>>> details = handler.getDetails('10.62.100.139')
>>> details.all
{'ip': '10.62.100.139', 'bogon': True, 'country_name': None, 'ip_address': IPv4Address('10.62.100.139'), 'latitude': None, 'longitude': None}
>>> details.latitude
>>> details.longitude
>>> details.bogon
True
```

and for public IPs:

```python
>>> details = handler.getDetails('9.9.9.9')
>>> details.all
{'ip': '9.9.9.9', 'hostname': 'dns.quad9.net', 'city': '', 'region': '', 'country': 'FR', 'loc': '48.8582,2.3387', 'org': 'AS19281 Quad9', 'country_name': 'France', 'ip_address': IPv4Address('9.9.9.9'), 'latitude': '48.8582', 'longitude': '2.3387'}
>>> details.latitude
'48.8582'
>>> details.longitude
'2.3387'
>>> details.loc
'48.8582,2.3387'
>>> details.country
'FR'
```