### PR TITLE
Implement versioned cache key.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # IPInfo Changelog
 
+## 4.2.0
+
+- Cache keys are now versioned.
+  This allows more reliable changes to cached data in the future without
+  causing confusing incompatibilities. This should be transparent to the user.
+  This is primarily useful for users with persistent cache implementations.
+
 ## 4.1.0
 
 - The SDK version is available via `ipinfo.version` as `SDK_VERSION`.

--- a/ipinfo/handler.py
+++ b/ipinfo/handler.py
@@ -21,6 +21,7 @@ from .handler_utils import (
     CACHE_TTL,
     REQUEST_TIMEOUT_DEFAULT,
     BATCH_REQ_TIMEOUT_DEFAULT,
+    cache_key,
 )
 from . import handler_utils
 
@@ -74,8 +75,12 @@ class Handler:
         ):
             ip_address = ip_address.exploded
 
-        if ip_address in self.cache:
-            return Details(self.cache[ip_address])
+        # check cache first.
+        try:
+            cached_ipaddr = self.cache[cache_key(ip_address)]
+            return Details(cached_ipaddr)
+        except KeyError:
+            pass
 
         # prepare req http opts
         req_opts = {**self.request_options}
@@ -95,7 +100,7 @@ class Handler:
 
         # format & cache
         handler_utils.format_details(details, self.countries)
-        self.cache[ip_address] = details
+        self.cache[cache_key(ip_address)] = details
 
         return Details(details)
 
@@ -153,9 +158,10 @@ class Handler:
             ):
                 ip_address = ip_address.exploded
 
-            if ip_address in self.cache:
-                result[ip_address] = self.cache[ip_address]
-            else:
+            try:
+                cached_ipaddr = self.cache[cache_key(ip_address)]
+                result[ip_address] = cached_ipaddr
+            except KeyError:
                 lookup_addresses.append(ip_address)
 
         # all in cache - return early.
@@ -201,7 +207,7 @@ class Handler:
             # fill cache
             json_response = response.json()
             for ip_address, details in json_response.items():
-                self.cache[ip_address] = details
+                self.cache[cache_key(ip_address)] = details
 
             # merge cached results with new lookup
             result.update(json_response)

--- a/ipinfo/handler_utils.py
+++ b/ipinfo/handler_utils.py
@@ -24,6 +24,10 @@ CACHE_MAXSIZE = 4096
 # The default TTL of the cache in seconds
 CACHE_TTL = 60 * 60 * 24
 
+# The current version of the cached data.
+# Update this if the data being cached has changed in shape for the same key.
+CACHE_KEY_VSN = "1"
+
 # The default request timeout for per-IP requests.
 REQUEST_TIMEOUT_DEFAULT = 2
 
@@ -93,3 +97,10 @@ def return_or_fail(raise_on_fail, e, v):
         raise e
     else:
         return v
+
+
+def cache_key(k):
+    """
+    Transforms a user-input key into a versioned cache key.
+    """
+    return f"{k}:{CACHE_KEY_VSN}"

--- a/ipinfo/version.py
+++ b/ipinfo/version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = "4.1.0"
+SDK_VERSION = "4.2.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,20 +4,20 @@
 #
 #    pip-compile --no-emit-index-url --no-emit-trusted-host
 #
-aiohttp==3.7.3            # via -r requirements.in
+aiohttp==3.7.4.post0      # via -r requirements.in
 appdirs==1.4.4            # via black
 async-timeout==3.0.1      # via aiohttp
 attrs==20.3.0             # via aiohttp, pytest
 black==20.8b1             # via -r requirements.in
 cachetools==4.2.0         # via -r requirements.in
 certifi==2020.12.5        # via requests
-chardet==3.0.4            # via aiohttp, requests
+chardet==4.0.0            # via aiohttp, requests
 click==7.1.2              # via black, pip-tools
 idna==2.10                # via requests, yarl
 iniconfig==1.1.1          # via pytest
 multidict==5.1.0          # via aiohttp, yarl
 mypy-extensions==0.4.3    # via black
-packaging==20.8           # via pytest
+packaging==20.9           # via pytest
 pathspec==0.8.1           # via black
 pip-tools==5.4.0          # via -r requirements.in
 pluggy==0.13.1            # via pytest
@@ -25,13 +25,13 @@ py==1.10.0                # via pytest
 pyparsing==2.4.7          # via packaging
 pytest-asyncio==0.14.0    # via -r requirements.in
 pytest==6.2.1             # via -r requirements.in, pytest-asyncio
-regex==2020.11.13         # via black
-requests==2.25.0          # via -r requirements.in
+regex==2021.4.4           # via black
+requests==2.25.1          # via -r requirements.in
 six==1.15.0               # via pip-tools
 toml==0.10.2              # via black, pytest
-typed-ast==1.4.1          # via black
+typed-ast==1.4.3          # via black
 typing-extensions==3.7.4.3  # via aiohttp, black
-urllib3==1.26.2           # via requests
+urllib3==1.26.4           # via requests
 yarl==1.6.3               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Additionally less lookups are now done in the success case. Previously, a lookup was done to see if the key exists, and then another to get it.

Closes #47 