### PR TITLE
Add `HandlerLite` and `AsyncHandlerLite` to support Lite API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 This is the official Python client library for the IPinfo.io IP address API, allowing you to look up your own IP address, or get any of the following details for an IP:
 
- - [IP geolocation](https://ipinfo.io/ip-geolocation-api) (city, region, country, postal code, latitude, and longitude)
- - [ASN details](https://ipinfo.io/asn-api) (ISP or network operator, associated domain name, and type, such as business, hosting, or company)
- - [Firmographics data](https://ipinfo.io/ip-company-api) (the name and domain of the business that uses the IP address)
- - [Carrier information](https://ipinfo.io/ip-carrier-api) (the name of the mobile carrier and MNC and MCC for that carrier if the IP is used exclusively for mobile traffic)
+- [IP geolocation](https://ipinfo.io/ip-geolocation-api) (city, region, country, postal code, latitude, and longitude)
+- [ASN details](https://ipinfo.io/asn-api) (ISP or network operator, associated domain name, and type, such as business, hosting, or company)
+- [Firmographics data](https://ipinfo.io/ip-company-api) (the name and domain of the business that uses the IP address)
+- [Carrier information](https://ipinfo.io/ip-carrier-api) (the name of the mobile carrier and MNC and MCC for that carrier if the IP is used exclusively for mobile traffic)
 
 ## Getting Started
 
@@ -13,7 +13,7 @@ You'll need an IPinfo API access token, which you can get by signing up for a fr
 
 The free plan is limited to 50,000 requests per month, and doesn't include some of the data fields such as IP type and company data. To enable all the data fields and additional request volumes see [https://ipinfo.io/pricing](https://ipinfo.io/pricing)
 
-⚠️ Note: This library does not currently support our newest free API https://ipinfo.io/lite. If you’d like to use IPinfo Lite, you can call the [endpoint directly](https://ipinfo.io/developers/lite-api) using your preferred HTTP client. Developers are also welcome to contribute support for Lite by submitting a pull request.
+The library also supports the Lite API, see the [Lite API section](#lite-api) for more info.
 
 ### Installation
 
@@ -162,6 +162,22 @@ The IPinfo library can be authenticated with your IPinfo API token, which is pas
  'timezone': 'America/Los_Angeles'}
 ```
 
+### Lite API
+
+The library gives the possibility to use the [Lite API](https://ipinfo.io/developers/lite-api) too, authentication with your token is still required.
+
+The returned details are slightly different from the Core API.
+
+```python
+>>> import ipinfo
+>>> handler = ipinfo.getHandlerLite(access_token='123456789abc')
+>>> details = handler.getDetails("8.8.8.8")
+>>> details.country_code
+'US'
+>>> details.country
+'United States'
+```
+
 ### Caching
 
 In-memory caching of `details` data is provided by default via the [cachetools](https://cachetools.readthedocs.io/en/latest/) library. This uses an LRU (least recently used) cache with a TTL (time to live) by default. This means that values will be cached for the specified duration; if the cache's max size is reached, cache values will be invalidated as necessary, starting with the oldest cached value.
@@ -297,6 +313,7 @@ When looking up an IP address, the response object includes `details.country_nam
     continents=continents
 )
 ```
+
 ### Batch Operations
 
 Looking up a single IP at a time can be slow. It could be done concurrently

--- a/ipinfo/__init__.py
+++ b/ipinfo/__init__.py
@@ -1,3 +1,5 @@
+from .handler_lite import HandlerLite
+from .handler_lite_async import AsyncHandlerLite
 from .handler import Handler
 from .handler_async import AsyncHandler
 
@@ -7,6 +9,16 @@ def getHandler(access_token=None, **kwargs):
     return Handler(access_token, **kwargs)
 
 
+def getHandlerLite(access_token=None, **kwargs):
+    """Create and return HandlerLite object."""
+    return HandlerLite(access_token, **kwargs)
+
+
 def getHandlerAsync(access_token=None, **kwargs):
     """Create an return an asynchronous Handler object."""
     return AsyncHandler(access_token, **kwargs)
+
+
+def getHandlerAsyncLite(access_token=None, **kwargs):
+    """Create and return asynchronous HandlerLite object."""
+    return AsyncHandlerLite(access_token, **kwargs)

--- a/ipinfo/handler_lite.py
+++ b/ipinfo/handler_lite.py
@@ -1,0 +1,139 @@
+"""
+Main API client handler for fetching data from the IPinfo service.
+"""
+
+from ipaddress import IPv4Address, IPv6Address
+
+import requests
+
+from .error import APIError
+from .cache.default import DefaultCache
+from .details import Details
+from .exceptions import RequestQuotaExceededError
+from .handler_utils import (
+    LITE_API_URL,
+    CACHE_MAXSIZE,
+    CACHE_TTL,
+    REQUEST_TIMEOUT_DEFAULT,
+    cache_key,
+)
+from . import handler_utils
+from .bogon import is_bogon
+from .data import (
+    continents,
+    countries,
+    countries_currencies,
+    eu_countries,
+    countries_flags,
+)
+
+
+class HandlerLite:
+    """
+    Allows client to request data for specified IP address using the Lite API.
+    Instantiates and maintains access to cache.
+    """
+
+    def __init__(self, access_token=None, **kwargs):
+        """
+        Initialize the Handler object with country name list and the
+        cache initialized.
+        """
+        self.access_token = access_token
+
+        # load countries file
+        self.countries = kwargs.get("countries") or countries
+
+        # load eu countries file
+        self.eu_countries = kwargs.get("eu_countries") or eu_countries
+
+        # load countries flags file
+        self.countries_flags = kwargs.get("countries_flags") or countries_flags
+
+        # load countries currency file
+        self.countries_currencies = (
+            kwargs.get("countries_currencies") or countries_currencies
+        )
+
+        # load continent file
+        self.continents = kwargs.get("continent") or continents
+
+        # setup req opts
+        self.request_options = kwargs.get("request_options", {})
+        if "timeout" not in self.request_options:
+            self.request_options["timeout"] = REQUEST_TIMEOUT_DEFAULT
+
+        # setup cache
+        if "cache" in kwargs:
+            self.cache = kwargs["cache"]
+        else:
+            cache_options = kwargs.get("cache_options", {})
+            if "maxsize" not in cache_options:
+                cache_options["maxsize"] = CACHE_MAXSIZE
+            if "ttl" not in cache_options:
+                cache_options["ttl"] = CACHE_TTL
+            self.cache = DefaultCache(**cache_options)
+
+        # setup custom headers
+        self.headers = kwargs.get("headers", None)
+
+    def getDetails(self, ip_address=None, timeout=None):
+        """
+        Get details for specified IP address as a Details object.
+
+        If `timeout` is not `None`, it will override the client-level timeout
+        just for this operation.
+        """
+        # If the supplied IP address uses the objects defined in the built-in
+        # module ipaddress extract the appropriate string notation before
+        # formatting the URL.
+        if isinstance(ip_address, IPv4Address) or isinstance(ip_address, IPv6Address):
+            ip_address = ip_address.exploded
+
+        # check if bogon.
+        if ip_address and is_bogon(ip_address):
+            details = {}
+            details["ip"] = ip_address
+            details["bogon"] = True
+            return Details(details)
+
+        # check cache first.
+        try:
+            cached_ipaddr = self.cache[cache_key(ip_address)]
+            return Details(cached_ipaddr)
+        except KeyError:
+            pass
+
+        # prepare req http opts
+        req_opts = {**self.request_options}
+        if timeout is not None:
+            req_opts["timeout"] = timeout
+
+        # not in cache; do http req
+        url = f"{LITE_API_URL}/{ip_address}" if ip_address else f"{LITE_API_URL}/me"
+        headers = handler_utils.get_headers(self.access_token, self.headers)
+        response = requests.get(url, headers=headers, **req_opts)
+        if response.status_code == 429:
+            raise RequestQuotaExceededError()
+        if response.status_code >= 400:
+            error_code = response.status_code
+            content_type = response.headers.get("Content-Type")
+            if content_type == "application/json":
+                error_response = response.json()
+            else:
+                error_response = {"error": response.text}
+            raise APIError(error_code, error_response)
+        details = response.json()
+
+        # format & cache
+        handler_utils.format_details(
+            details,
+            self.countries,
+            self.eu_countries,
+            self.countries_flags,
+            self.countries_currencies,
+            self.continents,
+        )
+        self.cache[cache_key(ip_address)] = details
+
+        return Details(details)

--- a/ipinfo/handler_lite_async.py
+++ b/ipinfo/handler_lite_async.py
@@ -1,0 +1,167 @@
+"""
+Main API client asynchronous handler for fetching data from the IPinfo service.
+"""
+
+from ipaddress import IPv4Address, IPv6Address
+
+import aiohttp
+
+from .error import APIError
+from .cache.default import DefaultCache
+from .details import Details
+from .exceptions import RequestQuotaExceededError
+from .handler_utils import (
+    CACHE_MAXSIZE,
+    CACHE_TTL,
+    LITE_API_URL,
+    REQUEST_TIMEOUT_DEFAULT,
+    cache_key,
+)
+from . import handler_utils
+from .bogon import is_bogon
+from .data import (
+    continents,
+    countries,
+    countries_currencies,
+    eu_countries,
+    countries_flags,
+)
+
+
+class AsyncHandlerLite:
+    """
+    Allows client to request data for specified IP address asynchronously using the Lite API.
+    Instantiates and maintains access to cache.
+    """
+
+    def __init__(self, access_token=None, **kwargs):
+        """
+        Initialize the Handler object with country name list and the
+        cache initialized.
+        """
+        self.access_token = access_token
+
+        # load countries file
+        self.countries = kwargs.get("countries") or countries
+
+        # load eu countries file
+        self.eu_countries = kwargs.get("eu_countries") or eu_countries
+
+        # load countries flags file
+        self.countries_flags = kwargs.get("countries_flags") or countries_flags
+
+        # load countries currency file
+        self.countries_currencies = (
+            kwargs.get("countries_currencies") or countries_currencies
+        )
+
+        # load continent file
+        self.continents = kwargs.get("continent") or continents
+
+        # setup req opts
+        self.request_options = kwargs.get("request_options", {})
+        if "timeout" not in self.request_options:
+            self.request_options["timeout"] = REQUEST_TIMEOUT_DEFAULT
+
+        # setup aiohttp
+        self.httpsess = None
+
+        # setup cache
+        if "cache" in kwargs:
+            self.cache = kwargs["cache"]
+        else:
+            cache_options = kwargs.get("cache_options", {})
+            if "maxsize" not in cache_options:
+                cache_options["maxsize"] = CACHE_MAXSIZE
+            if "ttl" not in cache_options:
+                cache_options["ttl"] = CACHE_TTL
+            self.cache = DefaultCache(**cache_options)
+
+        # setup custom headers
+        self.headers = kwargs.get("headers", None)
+
+    async def init(self):
+        """
+        Initializes internal aiohttp connection pool.
+
+        This isn't _required_, as the pool is initialized lazily when needed.
+        But in case you require non-lazy initialization, you may await this.
+
+        This is idempotent.
+        """
+        await self._ensure_aiohttp_ready()
+
+    async def deinit(self):
+        """
+        Deinitialize the async handler.
+
+        This is required in case you need to let go of the memory/state
+        associated with the async handler in a long-running process.
+
+        This is idempotent.
+        """
+        if self.httpsess:
+            await self.httpsess.close()
+            self.httpsess = None
+
+    async def getDetails(self, ip_address=None, timeout=None):
+        """Get details for specified IP address as a Details object."""
+        self._ensure_aiohttp_ready()
+
+        # If the supplied IP address uses the objects defined in the built-in
+        # module ipaddress, extract the appropriate string notation before
+        # formatting the URL.
+        if isinstance(ip_address, IPv4Address) or isinstance(ip_address, IPv6Address):
+            ip_address = ip_address.exploded
+
+        # check if bogon.
+        if ip_address and is_bogon(ip_address):
+            details = {"ip": ip_address, "bogon": True}
+            return Details(details)
+
+        # check cache first.
+        try:
+            cached_ipaddr = self.cache[cache_key(ip_address)]
+            return Details(cached_ipaddr)
+        except KeyError:
+            pass
+
+        # not in cache; do http req
+        url = f"{LITE_API_URL}/{ip_address}" if ip_address else f"{LITE_API_URL}/me"
+        headers = handler_utils.get_headers(self.access_token, self.headers)
+        req_opts = {}
+        if timeout is not None:
+            req_opts["timeout"] = timeout
+        async with self.httpsess.get(url, headers=headers, **req_opts) as resp:
+            if resp.status == 429:
+                raise RequestQuotaExceededError()
+            if resp.status >= 400:
+                error_code = resp.status
+                content_type = resp.headers.get("Content-Type")
+                if content_type == "application/json":
+                    error_response = await resp.json()
+                else:
+                    error_response = {"error": resp.text()}
+                raise APIError(error_code, error_response)
+            details = await resp.json()
+
+        # format & cache
+        handler_utils.format_details(
+            details,
+            self.countries,
+            self.eu_countries,
+            self.countries_flags,
+            self.countries_currencies,
+            self.continents,
+        )
+        self.cache[cache_key(ip_address)] = details
+
+        return Details(details)
+
+    def _ensure_aiohttp_ready(self):
+        """Ensures aiohttp internal state is initialized."""
+        if self.httpsess:
+            return
+
+        timeout = aiohttp.ClientTimeout(total=self.request_options["timeout"])
+        self.httpsess = aiohttp.ClientSession(timeout=timeout)

--- a/ipinfo/handler_utils.py
+++ b/ipinfo/handler_utils.py
@@ -12,6 +12,9 @@ from .version import SDK_VERSION
 # Base URL to make requests against.
 API_URL = "https://ipinfo.io"
 
+# Base URL for the IPinfo Lite API
+LITE_API_URL = "https://api.ipinfo.io/lite"
+
 # Base URL to get country flag image link.
 # "PK" -> "https://cdn.ipinfo.io/static/images/countries-flags/PK.svg"
 COUNTRY_FLAGS_URL = "https://cdn.ipinfo.io/static/images/countries-flags/"

--- a/tests/handler_lite_async_test.py
+++ b/tests/handler_lite_async_test.py
@@ -1,0 +1,169 @@
+import json
+import os
+
+from ipinfo.cache.default import DefaultCache
+from ipinfo.details import Details
+from ipinfo import handler_utils
+from ipinfo.error import APIError
+import pytest
+import aiohttp
+
+from ipinfo.handler_lite_async import AsyncHandlerLite
+
+
+class MockResponse:
+    def __init__(self, text, status, headers):
+        self._text = text
+        self.status = status
+        self.headers = headers
+
+    def text(self):
+        return self._text
+
+    async def json(self):
+        return json.loads(self._text)
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def release(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_init():
+    token = "mytesttoken"
+    handler = AsyncHandlerLite(token)
+    assert handler.access_token == token
+    assert isinstance(handler.cache, DefaultCache)
+    assert "PK" in handler.countries
+    await handler.deinit()
+
+
+@pytest.mark.asyncio
+async def test_headers():
+    token = "mytesttoken"
+    handler = AsyncHandlerLite(token, headers={"custom_field": "yes"})
+    headers = handler_utils.get_headers(token, handler.headers)
+    await handler.deinit()
+
+    assert "user-agent" in headers
+    assert "accept" in headers
+    assert "authorization" in headers
+    assert "custom_field" in headers
+
+
+@pytest.mark.skipif(
+    "IPINFO_LITE_TOKEN" not in os.environ,
+    reason="Can't call Lite API without token",
+)
+@pytest.mark.asyncio
+async def test_get_details():
+    token = os.environ.get("IPINFO_LITE_TOKEN", "")
+    handler = AsyncHandlerLite(token)
+    details = await handler.getDetails("8.8.8.8")
+    assert isinstance(details, Details)
+    assert details.ip == "8.8.8.8"
+    assert details.asn == "AS15169"
+    assert details.as_name == "Google LLC"
+    assert details.as_domain == "google.com"
+    assert details.country_code == "US"
+    assert details.country == "United States"
+    assert details.continent_code == "NA"
+    assert details.continent is None
+    assert details.country_name is None
+    assert not details.isEU
+    assert (
+        details.country_flag_url
+        == "https://cdn.ipinfo.io/static/images/countries-flags/United States.svg"
+    )
+    assert details.country_flag is None
+    assert details.country_currency is None
+    assert details.latitude is None
+    assert details.longitude is None
+
+    await handler.deinit()
+
+
+@pytest.mark.skipif(
+    "IPINFO_LITE_TOKEN" not in os.environ,
+    reason="Can't call Lite API without token",
+)
+@pytest.mark.parametrize(
+    (
+        "mock_resp_status_code",
+        "mock_resp_headers",
+        "mock_resp_error_msg",
+        "expected_error_json",
+    ),
+    [
+        pytest.param(
+            503,
+            {"Content-Type": "text/plain"},
+            "Service Unavailable",
+            {"error": "Service Unavailable"},
+            id="5xx_not_json",
+        ),
+        pytest.param(
+            403,
+            {"Content-Type": "application/json"},
+            '{"message": "missing token"}',
+            {"message": "missing token"},
+            id="4xx_json",
+        ),
+        pytest.param(
+            400,
+            {"Content-Type": "application/json"},
+            '{"message": "missing field"}',
+            {"message": "missing field"},
+            id="400",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_details_error(
+    monkeypatch,
+    mock_resp_status_code,
+    mock_resp_headers,
+    mock_resp_error_msg,
+    expected_error_json,
+):
+    async def mock_get(*args, **kwargs):
+        response = MockResponse(
+            status=mock_resp_status_code,
+            text=mock_resp_error_msg,
+            headers=mock_resp_headers,
+        )
+        return response
+
+    monkeypatch.setattr(
+        aiohttp.ClientSession,
+        "get",
+        lambda *args, **kwargs: aiohttp.client._RequestContextManager(mock_get()),
+    )
+    token = os.environ.get("IPINFO_LITE_TOKEN", "")
+    handler = AsyncHandlerLite(token)
+    with pytest.raises(APIError) as exc_info:
+        await handler.getDetails("8.8.8.8")
+    assert exc_info.value.error_code == mock_resp_status_code
+    assert exc_info.value.error_json == expected_error_json
+
+
+#############
+# BOGON TESTS
+#############
+
+
+@pytest.mark.skipif(
+    "IPINFO_LITE_TOKEN" not in os.environ,
+    reason="Can't call Lite API without token",
+)
+@pytest.mark.asyncio
+async def test_bogon_details():
+    token = os.environ.get("IPINFO_LITE_TOKEN", "")
+    handler = AsyncHandlerLite(token)
+    details = await handler.getDetails("127.0.0.1")
+    assert details.all == {"bogon": True, "ip": "127.0.0.1"}

--- a/tests/handler_lite_test.py
+++ b/tests/handler_lite_test.py
@@ -1,0 +1,72 @@
+import os
+
+import pytest
+from ipinfo import handler_utils
+from ipinfo.cache.default import DefaultCache
+from ipinfo.details import Details
+from ipinfo.handler_lite import HandlerLite
+
+
+def test_init():
+    token = "mytesttoken"
+    handler = HandlerLite(token)
+    assert handler.access_token == token
+    assert isinstance(handler.cache, DefaultCache)
+    assert "US" in handler.countries
+
+
+def test_headers():
+    token = "mytesttoken"
+    handler = HandlerLite(token, headers={"custom_field": "yes"})
+    headers = handler_utils.get_headers(token, handler.headers)
+
+    assert "user-agent" in headers
+    assert "accept" in headers
+    assert "authorization" in headers
+    assert "custom_field" in headers
+
+
+@pytest.mark.skipif(
+    "IPINFO_LITE_TOKEN" not in os.environ,
+    reason="Can't call Lite API without token",
+)
+def test_get_details():
+    token = os.environ.get("IPINFO_LITE_TOKEN", "")
+    handler = HandlerLite(token)
+    details = handler.getDetails("8.8.8.8")
+    assert isinstance(details, Details)
+    assert details.ip == "8.8.8.8"
+    assert details.asn == "AS15169"
+    assert details.as_name == "Google LLC"
+    assert details.as_domain == "google.com"
+    assert details.country_code == "US"
+    assert details.country == "United States"
+    assert details.continent_code == "NA"
+    assert details.continent is None
+    assert details.country_name is None
+    assert not details.isEU
+    assert (
+        details.country_flag_url
+        == "https://cdn.ipinfo.io/static/images/countries-flags/United States.svg"
+    )
+    assert details.country_flag is None
+    assert details.country_currency is None
+    assert details.latitude is None
+    assert details.longitude is None
+
+
+#############
+# BOGON TESTS
+#############
+
+
+@pytest.mark.skipif(
+    "IPINFO_LITE_TOKEN" not in os.environ,
+    reason="Can't call Lite API without token",
+)
+def test_bogon_details():
+    token = os.environ.get("IPINFO_LITE_TOKEN", "")
+    handler = HandlerLite(token)
+    details = handler.getDetails("127.0.0.1")
+    assert isinstance(details, Details)
+    assert details.all == {"bogon": True, "ip": "127.0.0.1"}


### PR DESCRIPTION
This PR adds two new classes so users can leverage the [new Lite API](https://ipinfo.io/developers/lite-api).

Since the new API returns different information and objects from the Core API I decided to create new classes instead of extending the existing ones. The internal logic between the Core and Lite version is completely identical, in fact I copied and pasted it to move fast.

In the future we might standardize the internal logic to avoid duplication.

I also added new tests and updated the `README.md` with minimal info to use the Lite API.