### PR TITLE
Loosen dependency pins: cachetools, aiohttp, requests

### DIFF
--- a/ipinfo/cache/default.py
+++ b/ipinfo/cache/default.py
@@ -2,16 +2,14 @@
 A default cache implementation that uses `cachetools` for an in-memory LRU cache.
 """
 
-import cachetools
-
 from .interface import CacheInterface
-
+from cachetools import TTLCache
 
 class DefaultCache(CacheInterface):
     """Default, in-memory cache."""
 
     def __init__(self, **cache_options):
-        self.cache = cachetools.TTLCache(**cache_options)
+        self.cache = TTLCache(**cache_options)
 
     def __contains__(self, key):
         return self.cache.__contains__(key)

--- a/ipinfo/handler_async.py
+++ b/ipinfo/handler_async.py
@@ -150,7 +150,7 @@ class AsyncHandler:
                 if content_type == "application/json":
                     error_response = await resp.json()
                 else:
-                    error_response = {"error": resp.text()}
+                    error_response = {"error": await resp.text()}
                 raise APIError(error_code, error_response)
             details = await resp.json()
 
@@ -208,7 +208,7 @@ class AsyncHandler:
                 if content_type == "application/json":
                     error_response = await resp.json()
                 else:
-                    error_response = {"error": resp.text()}
+                    error_response = {"error": await resp.text()}
                 raise APIError(error_code, error_response)
             details = await resp.json()
 

--- a/ipinfo/handler_core_async.py
+++ b/ipinfo/handler_core_async.py
@@ -153,7 +153,7 @@ class AsyncHandlerCore:
                 if content_type == "application/json":
                     error_response = await resp.json()
                 else:
-                    error_response = {"error": resp.text()}
+                    error_response = {"error": await resp.text()}
                 raise APIError(error_code, error_response)
             details = await resp.json()
 

--- a/ipinfo/handler_lite_async.py
+++ b/ipinfo/handler_lite_async.py
@@ -141,7 +141,7 @@ class AsyncHandlerLite:
                 if content_type == "application/json":
                     error_response = await resp.json()
                 else:
-                    error_response = {"error": resp.text()}
+                    error_response = {"error": await resp.text()}
                 raise APIError(error_code, error_response)
             details = await resp.json()
 

--- a/ipinfo/handler_plus_async.py
+++ b/ipinfo/handler_plus_async.py
@@ -153,7 +153,7 @@ class AsyncHandlerPlus:
                 if content_type == "application/json":
                     error_response = await resp.json()
                 else:
-                    error_response = {"error": resp.text()}
+                    error_response = {"error": await resp.text()}
                 raise APIError(error_code, error_response)
             details = await resp.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ authors = [
 license = { text = "Apache License 2.0" }
 requires-python = ">=3.10"
 dependencies = [
-    "requests>=2.18.4",
-    "cachetools==4.2.0",
-    "aiohttp>=3.12.14,<=4",
+    "requests>=2.18.4,<3",
+    "cachetools>=4.2,<8",
+    "aiohttp>=3,<4",
 ]
 
 [project.urls]

--- a/tests/handler_async_test.py
+++ b/tests/handler_async_test.py
@@ -22,7 +22,7 @@ class MockResponse:
         self.status = status
         self.headers = headers
 
-    def text(self):
+    async def text(self):
         return self._text
 
     async def json(self):

--- a/tests/handler_lite_async_test.py
+++ b/tests/handler_lite_async_test.py
@@ -17,7 +17,7 @@ class MockResponse:
         self.status = status
         self.headers = headers
 
-    def text(self):
+    async def text(self):
         return self._text
 
     async def json(self):

--- a/uv.lock
+++ b/uv.lock
@@ -489,9 +489,9 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiohttp", specifier = ">=3.12.14,<=4" },
-    { name = "cachetools", specifier = "==4.2.0" },
-    { name = "requests", specifier = ">=2.18.4" },
+    { name = "aiohttp", specifier = ">=3,<4" },
+    { name = "cachetools", specifier = ">=4.2,<8" },
+    { name = "requests", specifier = ">=2.18.4,<3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

Loosens overly strict dependency pins that cause conflicts with other packages in the same environment.

Fixes #127

## Changes

| Dependency | Before | After | Reason |
|---|---|---|---|
| `cachetools` | `==4.2.0` | `>=4.2,<8` | Hard pin to a 6-year-old version blocks users with other packages requiring `cachetools>=5/6/7`. Tested compatible with cachetools 7.0.5. |
| `aiohttp` | `>=3.12.14,<=4` | `>=3,<4` | `<=4` only allowed exactly `4.0.0`, unintentionally excluding `4.0.1+`. Changed to `<4` to correctly express the intent of staying on the v3 series. |
| `requests` | `>=2.18.4` | `>=2.18.4,<3` | Added upper bound to avoid unexpected breakage if a future v3 introduces breaking changes. |

## Testing

All existing tests pass with cachetools 7.0.5 and the updated constraints.