### PR TITLE
fix(handler): replace raise e with bare raise and use is None

### DIFF
--- a/ipinfo/handler.py
+++ b/ipinfo/handler.py
@@ -232,7 +232,7 @@ class Handler:
         quota errors.
         Defaults to on.
         """
-        if batch_size == None:
+        if batch_size is None:
             batch_size = BATCH_MAX_SIZE
 
         result = {}
@@ -391,8 +391,8 @@ class Handler:
 
             try:
                 response = requests.post(url, json=batch, headers=headers)
-            except Exception as e:
-                raise e
+            except Exception:
+                raise
 
             try:
                 if response.status_code == 429:


### PR DESCRIPTION
## Summary

Fixes an exception chaining anti-pattern in `Handler.getBatchDetailsIter` that was masking original tracebacks, and applies PEP 8 style consistency in `getBatchDetails`.

### Changes

1. **Replace `raise e` with bare `raise` (line 395)**

   `raise e` creates a new exception without preserving the original traceback,
   making debugging significantly harder. Bare `raise` re-raises the active
   exception while keeping the full chain intact.

2. **Use `is None` instead of `== None` in `getBatchDetails` (line 235)**

   PEP 8 style consistency — the sibling method `getBatchDetailsIter` already
   uses `is None`.

### Impact

- Tracebacks from network and HTTP errors are now fully actionable.
- No behaviour change for successful requests or existing callers.

### Verification

```bash
python3 -m py_compile ipinfo/handler.py   # passes
```